### PR TITLE
IE compatibility mode

### DIFF
--- a/layouts/partials/head-meta.html
+++ b/layouts/partials/head-meta.html
@@ -1,4 +1,5 @@
 <meta charset="utf-8">
+<meta http-equiv="x-ua-compatible" content="ie=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
Internet Explorer supports the use of a document compatibility <meta> tag to specify what version of IE the page should be rendered as. Unless circumstances require otherwise, it's most useful to instruct IE to use the latest supported mode with edge mode.
REF: http://codeguide.co/#html-ie-compatibility-mode