### PR TITLE
Extract post-title partial

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,8 +1,6 @@
 <article class="blog-post">
     <header>
-        <h2 class="blog-post-title">
-            <a class="text-dark" href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a>
-        </h2>
+        {{ partial "post-title" . }}
         {{ partial "post-date" . }}
         {{ partial "post-tags" . }}
         {{ partial "post-categories" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,7 @@
 {{ define "main" }}
 
 <header>
-    <h2 class="blog-post-title">
-        <a class="text-dark" href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a>
-    </h2>
+    {{ partial "post-title" . }}
     {{ partial "post-date" . }}
     {{ partial "post-tags" . }}
     {{ partial "post-categories" . }}

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,8 +1,6 @@
 <article class="blog-post">
     <header>
-        <h2 class="blog-post-title">
-            <a class="text-dark" href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a>
-        </h2>
+        {{ partial "post-title" . }}
         {{ partial "post-date" . }}
         {{ partial "post-tags" . }}
         {{ partial "post-categories" . }}
@@ -13,4 +11,3 @@
     <a href="{{ .RelPermalink }}">{{ i18n "readMore" }}</a>
     {{ end }}
 </article>
-

--- a/layouts/partials/post-title.html
+++ b/layouts/partials/post-title.html
@@ -1,0 +1,3 @@
+<h2 class="blog-post-title">
+    <a class="text-dark" href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a>
+</h2>


### PR DESCRIPTION
This PR exposes a `post-title.html` partial that can be overridden by the theme consumer. Since the same header format is used across a couple templates, they've been replaced by the partial.