### PR TITLE
Display content for an index page if avaliable

### DIFF
--- a/exampleSite/content/post/_index.md
+++ b/exampleSite/content/post/_index.md
@@ -1,0 +1,4 @@
+---
+title: Posts
+---
+Hello world!

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,6 +2,18 @@
 
 {{ $truncate := default true .Site.Params.truncate }}
 
+{{ if .Content }}
+<header>
+    <h1 class="blog-post-title">
+        <a class="text-dark" href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a>
+    </h1>
+    <hr>
+</header>
+<section class="blog-post">
+    {{ .Content }}
+</section>
+{{ end }}
+
 {{ $paginator := .Paginate (where .Pages "Type" "post") }}
 {{ range $paginator.Pages }}
 
@@ -16,4 +28,3 @@
 {{ partial "paginator" . }}
 
 {{ end }}
-


### PR DESCRIPTION
Hugo lets users create [index pages](https://gohugo.io/content-management/organization/#index-pages-index-md), but their content isn't displayed by default in this theme. This PR adds a top section with the page title and content, if an `_index.html` page was defined.

![Demo](https://user-images.githubusercontent.com/1782266/50568743-6b72d580-0d0b-11e9-8eea-d4a97c473ba4.png)
