### PR TITLE
Move translations to partial & remove index pages from recent

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,17 +10,7 @@
 <article class="blog-post">
     {{ .Content }}
 
-    {{ if .IsTranslated }}
-      <h4>{{ i18n "translations" }}</h4>
-      <ul>
-        {{ range .Translations }}
-        <li>
-          <a href="{{ .RelPermalink }}">{{ .Lang }}: {{ .Title }}</a>
-        </li>
-        {{ end }}
-      </ul>
-    {{ end }}
-
+    {{ partial "translations" . }}
     {{ partial "related" . }}
 
 </article>

--- a/layouts/partials/recent.html
+++ b/layouts/partials/recent.html
@@ -1,12 +1,12 @@
 {{ $num_recent_posts := default 5 .Site.Params.sidebar.num_recent_posts }}
-{{ $posts := first $num_recent_posts (where .Site.Pages "Section" "in" .Site.Params.mainSections) }}
+{{ $posts := first $num_recent_posts (where .Site.RegularPages "Section" "in" .Site.Params.mainSections) }}
 {{ if gt (len $posts) 0 }}
 <section>
     <h4>{{ i18n "recentPosts" }}</h4>
     <ol class="list-unstyled">
         {{ range $posts }}
         <li>
-            <a href="{{.RelPermalink}}">{{.Title | markdownify }}</a>
+            <a href="{{.RelPermalink}}">{{ .Title | markdownify }}</a>
         </li>
         {{ end }}
     </ol>

--- a/layouts/partials/translations.html
+++ b/layouts/partials/translations.html
@@ -1,0 +1,10 @@
+{{ if .IsTranslated }}
+    <h4>{{ i18n "translations" }}</h4>
+    <ul>
+        {{ range .Translations }}
+        <li>
+            <a href="{{ .RelPermalink }}">{{ .Lang }}: {{ .Title }}</a>
+        </li>
+        {{ end }}
+    </ul>
+{{ end }}


### PR DESCRIPTION
- Moved the links to translations into a partial so that theme users can reuse it in overrides.
- Changed the Recent Posts section in the sidebar to ignore section index pages